### PR TITLE
Target only .form-row table rows

### DIFF
--- a/inline_orderable/static/tabularinline_orderable.js
+++ b/inline_orderable/static/tabularinline_orderable.js
@@ -38,7 +38,7 @@
         };
     
     $.fn.tabularInlineOrder.defaults = {
-            'inlineItemsSel': 'tbody tr'
+            'inlineItemsSel': 'tbody tr.form-row'
         };
     
     


### PR DESCRIPTION
This prevents the .add-row from being included in the eligible rows during the drag & drag operations.

Thanks for putting this package together, it was exactly what I was looking for -- nice and simple!

Do you have any intentions of releasing it to PyPI?
