### PR TITLE
Add a specific "handle" to tabular inlines

### DIFF
--- a/inline_orderable/static/tabularinline_orderable.js
+++ b/inline_orderable/static/tabularinline_orderable.js
@@ -22,13 +22,13 @@
                 inlineGroup.find(opts.inlineItemsSel).find('td').not('.handle').css('cursor', 'inherit');
         
                 // finding header of order
-                var orderHeaderIndex = inlineGroup.find('td.order:first').index()-1,
+                var orderHeaderIndex = inlineGroup.find('input[id$=order]').index()+1,
                     orderTheadTH = inlineGroup.find('thead th:eq('+orderHeaderIndex+')'),
                     orderTheadTHColspan = parseInt(orderTheadTH.attr('colspan') || 1);
                 
                 // hiding stuff
                 if (orderTheadTHColspan == 2) {
-                    orderTheadTH.attr('colspan', orderTheadTHColspan-1);
+                    orderTheadTH.attr('colspan', 1);
                     orderTheadTH.text('');
                 } else {
                     orderTheadTH.hide();

--- a/inline_orderable/static/tabularinline_orderable.js
+++ b/inline_orderable/static/tabularinline_orderable.js
@@ -5,16 +5,21 @@
             return this.each(function() {
                 var inlineGroup = $(this);
                 
+                $('<th width="5">&#11021;</th>').prependTo(inlineGroup.find('thead tr:first'));
+                $('<td class="handle"></td>').prependTo(inlineGroup.find(opts.inlineItemsSel));
+                inlineGroup.find("table").addClass("orderable");
+
                 inlineGroup.sortable({
                     items: opts.inlineItemsSel,
-                    handle: 'td',
+                    handle: '.handle',
                     update: function() {
                         updateOrdering(inlineGroup.find(opts.inlineItemsSel));
                     }
                 });
         
                 // cursor move
-                inlineGroup.find(opts.inlineItemsSel).css('cursor', 'move');
+                inlineGroup.find('.handle').css('cursor', 'move');
+                inlineGroup.find(opts.inlineItemsSel).find('td').not('.handle').css('cursor', 'inherit');
         
                 // finding header of order
                 var orderHeaderIndex = inlineGroup.find('td.order:first').index()-1,
@@ -29,7 +34,7 @@
                     orderTheadTH.hide();
                 }
                 inlineGroup.find('input[id$=order]').parents('td').hide();
-                
+
                 // catching submit event
                 $('form').submit(function() {
                     updateOrdering(inlineGroup.find(opts.inlineItemsSel));


### PR DESCRIPTION
Previously the whole table row became a handle. I find that having a
specific handle element is a more natural interface for users and
prevents accidental reordering.
